### PR TITLE
Update package and README names to match repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# about-me
+# about
 
 Personal site of [Andrew H. Carpenter](https://github.com/ahcarpenter) — built
 with Next.js (App Router, static export) and Tailwind CSS v4, deployed to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "about-me",
+  "name": "about",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "about-me",
+      "name": "about",
       "version": "1.0.0",
       "dependencies": {
         "next": "^16.2.10",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "about-me",
+  "name": "about",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Follow-up to #24, now that the repository has been renamed to `about`: updates the `package.json` name field, the lockfile, and the README title from `about-me` to `about` so the code matches the repo name.

No functional changes — the next Pages deploy picks up the renamed repo's base path automatically via `configure-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5)_