### PR TITLE
Ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      # TypeScript >=6 (incl. the TS 7 native compiler) breaks Next.js 16's
+      # build-time typechecker — revisit once Next supports it.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Follow-up to closing #30: TypeScript 7 (and the 6.x line) crashes Next.js 16's build-time typechecker, which is why this repo is pinned to 5.x. This adds a Dependabot `ignore` rule for TypeScript semver-major updates so the same PR doesn't get re-proposed on every new major release. Minor and patch updates within 5.x continue to flow.

Revisit once Next.js supports the TS native compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5)_