### PR TITLE
Use Andrew instead of Drew; link LinkedIn activity to posts

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <rect width="64" height="64" rx="14" fill="#fbf6ed"/>
   <rect x="1" y="1" width="62" height="62" rx="13" fill="none" stroke="#e8dfcc" stroke-width="2"/>
-  <text x="32" y="44" text-anchor="middle" font-family="Georgia, serif" font-style="italic" font-size="34" fill="#c9512c">dc</text>
+  <text x="32" y="44" text-anchor="middle" font-family="Georgia, serif" font-style="italic" font-size="34" fill="#c9512c">ac</text>
 </svg>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,7 @@ function Hero() {
       <div>
         <p className="kicker">Hello, I’m</p>
         <h1 className="display mt-3 text-5xl sm:text-6xl md:text-7xl">
-          Drew <em>Carpenter</em>
+          Andrew <em>Carpenter</em>
         </h1>
         <p className="mt-6 max-w-xl text-lg leading-relaxed text-soft">
           {site.tagline} I spend my days shipping things, writing about what I

--- a/components/ChatStub.tsx
+++ b/components/ChatStub.tsx
@@ -8,13 +8,13 @@ type Message = { role: "me" | "bot"; text: string };
 /**
  * Stubbed "chat with AI me" — canned responses only. Swap `reply()` for a
  * real model call (e.g. an API route on a server deployment, or a hosted
- * endpoint) when the AI version of Drew is ready.
+ * endpoint) when the AI version of Andrew is ready.
  */
 const CANNED: string[] = [
-  "Good question. The honest answer: I'm a stub. The real AI-Drew is still in training — for now I only know how to say charming placeholder things.",
-  "If I were the real Drew, I'd probably answer with a story, a strong opinion, and a link to something he wrote. Soon.",
+  "Good question. The honest answer: I'm a stub. The real AI-Andrew is still in training — for now I only know how to say charming placeholder things.",
+  "If I were the real Andrew, I'd probably answer with a story, a strong opinion, and a link to something he wrote. Soon.",
   "I've noted that down for the actual AI version of me. In the meantime, the Philosophy and Story pages are the closest thing to my brain in text form.",
-  "Ask me again after my weights arrive. Until then: yes, Drew really does think writing is thinking.",
+  "Ask me again after my weights arrive. Until then: yes, Andrew really does think writing is thinking.",
   "That's beyond my canned repertoire — but the human me reads everything sent through LinkedIn or Substack, and he's friendlier than average.",
 ];
 

--- a/data/linkedin.ts
+++ b/data/linkedin.ts
@@ -21,6 +21,12 @@ export type LinkedInActivity = {
   /** ISO date, used for sorting the merged front-page feed. */
   date: string;
   title: string;
+  /**
+   * Permalink to the specific post/comment, NOT the profile. On LinkedIn,
+   * open the post's ··· menu → "Copy link to post"; it looks like
+   * https://www.linkedin.com/feed/update/urn:li:activity:1234567890/
+   * or https://www.linkedin.com/posts/andrewhcarpenter_slug-activity-1234567890/
+   */
   url: string;
   sample?: boolean;
 };
@@ -28,41 +34,43 @@ export type LinkedInActivity = {
 export const recommendations: Recommendation[] = [
   {
     quote:
-      "Drew is the rare engineer who cares as much about why something is being built as how. He asks the question that reframes the whole project — then quietly ships the thing.",
+      "Andrew is the rare engineer who cares as much about why something is being built as how. He asks the question that reframes the whole project — then quietly ships the thing.",
     name: "Jane Doe",
     title: "Engineering Manager",
-    relationship: "Managed Drew directly",
+    relationship: "Managed Andrew directly",
     sample: true,
   },
   {
     quote:
-      "Every team has someone people go to when they're stuck. On ours, that was Drew. Generous with his time, allergic to hand-waving, and unreasonably good at naming things.",
+      "Every team has someone people go to when they're stuck. On ours, that was Andrew. Generous with his time, allergic to hand-waving, and unreasonably good at naming things.",
     name: "John Smith",
     title: "Staff Engineer",
-    relationship: "Worked with Drew on the same team",
+    relationship: "Worked with Andrew on the same team",
     sample: true,
   },
   {
     quote:
-      "Drew turned a vague idea into a working product faster than I thought possible, and explained every trade-off along the way in plain English.",
+      "Andrew turned a vague idea into a working product faster than I thought possible, and explained every trade-off along the way in plain English.",
     name: "Alex Roe",
     title: "Product Lead",
-    relationship: "Was Drew's stakeholder",
+    relationship: "Was Andrew's stakeholder",
     sample: true,
   },
 ];
 
 export const linkedinActivity: LinkedInActivity[] = [
+  // Sample entries link to the recent-activity feed until replaced with
+  // real posts — swap each url for the post's own permalink (see type docs).
   {
     date: "2026-07-01",
     title: "Shared a post about building personal software in the age of coding agents",
-    url: "https://www.linkedin.com/in/andrewhcarpenter",
+    url: "https://www.linkedin.com/in/andrewhcarpenter/recent-activity/all/",
     sample: true,
   },
   {
     date: "2026-06-18",
     title: "Commented on a thread about engineering career ladders",
-    url: "https://www.linkedin.com/in/andrewhcarpenter",
+    url: "https://www.linkedin.com/in/andrewhcarpenter/recent-activity/comments/",
     sample: true,
   },
 ];

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,8 +1,8 @@
 /** Central place for identity + external profile links. */
 export const site = {
   name: "Andrew H. Carpenter",
-  shortName: "Drew Carpenter",
-  firstName: "Drew",
+  shortName: "Andrew Carpenter",
+  firstName: "Andrew",
   tagline: "Builder of software, collector of ideas.",
   description:
     "Personal site of Andrew H. Carpenter — what I'm building, writing, reading, and thinking about.",


### PR DESCRIPTION
## Summary

- Copy now reads **Andrew Carpenter** throughout: hero heading, header wordmark and footer (via `lib/site.ts`), chat-stub persona ("AI Andrew"), and the sample recommendation quotes. The favicon monogram changes from "dc" to "ac" to match.
- **LinkedIn activity entries link to the activity item, not the profile.** The `LinkedInActivity` type now documents that `url` takes the post's own permalink (··· menu → "Copy link to post"). The two sample rows point at the recent-activity feed until real posts are pasted in — a real per-post permalink can't be fetched automatically since LinkedIn activity is auth-walled.

## Verification

- `next build` (static export) passes
- Confirmed the built output contains no remaining "Drew" copy and the new activity URLs ship in the client bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5)_