### PR TITLE
Tighten hero description to two lines

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,9 +41,7 @@ function Hero() {
           Andrew <em>Carpenter</em>
         </h1>
         <p className="mt-6 max-w-xl text-lg leading-relaxed text-soft">
-          {site.tagline} I spend my days shipping things, writing about what I
-          learn along the way, and chasing the occasional idea further than is
-          strictly sensible. This site is the running record — live from{" "}
+          {site.tagline} This is the running record — live from{" "}
           <a href={site.githubUrl} className="font-medium text-accent hover:text-accent-deep" target="_blank" rel="noopener noreferrer">
             GitHub
           </a>


### PR DESCRIPTION
## Summary

Trims the landing-page hero description down to the tagline plus one sentence, so it wraps to two lines at desktop width instead of five. Copy-only change — no other files touched.

Before: *"Builder of software, collector of ideas. I spend my days shipping things, writing about what I learn along the way, and chasing the occasional idea further than is strictly sensible. This site is the running record — live from GitHub, Substack, and LinkedIn."*

After: *"Builder of software, collector of ideas. This is the running record — live from GitHub, Substack, and LinkedIn."*

## Verification

Rendered the built page in headless Chromium and confirmed the paragraph occupies exactly two line boxes at 1280px width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVffewSvpL9f3tHA86c3D5)_