### PR TITLE
fix: report true push commit counts from event size

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -21,11 +21,30 @@ describe("describeGithubEvent", () => {
 
   it("describes pushes with commit count and pluralization", () => {
     expect(
-      describeGithubEvent({ ...base, type: "PushEvent", payload: { commits: [{}] } })?.title,
+      describeGithubEvent({ ...base, type: "PushEvent", payload: { size: 1, commits: [{}] } })
+        ?.title,
     ).toBe("Pushed 1 commit to u/repo");
     expect(
-      describeGithubEvent({ ...base, type: "PushEvent", payload: { commits: [{}, {}] } })?.title,
+      describeGithubEvent({ ...base, type: "PushEvent", payload: { size: 2, commits: [{}, {}] } })
+        ?.title,
     ).toBe("Pushed 2 commits to u/repo");
+  });
+
+  it("uses size, not the truncated commits array, for large pushes", () => {
+    // The Events API caps `commits` at 20 entries; `size` carries the real total.
+    expect(
+      describeGithubEvent({
+        ...base,
+        type: "PushEvent",
+        payload: { size: 42, commits: Array.from({ length: 20 }, () => ({})) },
+      })?.title,
+    ).toBe("Pushed 42 commits to u/repo");
+  });
+
+  it("falls back to the commits array when size is absent", () => {
+    expect(
+      describeGithubEvent({ ...base, type: "PushEvent", payload: { commits: [{}, {}, {}] } })?.title,
+    ).toBe("Pushed 3 commits to u/repo");
   });
 
   it("describes repository and branch creation, skips tags", () => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -21,6 +21,7 @@ export type GithubEvent = {
   created_at?: string;
   repo?: { name?: string };
   payload?: {
+    size?: number;
     commits?: unknown[];
     ref?: string;
     ref_type?: string;
@@ -44,7 +45,9 @@ export function describeGithubEvent(ev: GithubEvent): GithubFeedItem | null {
   const base = { date: ev.created_at ?? "", url: repoUrl };
   switch (ev.type) {
     case "PushEvent": {
-      const n = ev.payload?.commits?.length ?? 0;
+      // The Events API truncates `commits` to 20 entries, so `size` is the only
+      // reliable total for larger pushes; fall back to the array length.
+      const n = ev.payload?.size ?? ev.payload?.commits?.length ?? 0;
       return { ...base, title: `Pushed ${n} commit${n === 1 ? "" : "s"} to ${repo}` };
     }
     case "CreateEvent":


### PR DESCRIPTION
The GitHub Events API truncates a PushEvent's `commits` array to 20
entries, so `commits.length` undercounts any push of more than 20
commits. Use the payload's `size` field (the authoritative total) and
fall back to the array length only when it's absent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5cpJ79USmXJXXnQmQGGzS