### PR TITLE
UI polish: oklch palette, typography and contrast fixes, hit areas

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -24,13 +24,23 @@ export default function ChatPage() {
         <ChatStub />
       </div>
 
-      <p className="mt-4 font-mono text-xs leading-relaxed text-faint">
+      <p className="mt-4 font-mono text-xs leading-relaxed text-muted">
         Prefer the human? Find him on{" "}
-        <a href={site.linkedinUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-accent">
+        <a
+          href={site.linkedinUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline decoration-line underline-offset-4 hover:text-accent"
+        >
           LinkedIn ↗
         </a>{" "}
         or reply to any post on{" "}
-        <a href={site.substackUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-accent">
+        <a
+          href={site.substackUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline decoration-line underline-offset-4 hover:text-accent"
+        >
           Substack ↗
         </a>
         .

--- a/app/globals.css
+++ b/app/globals.css
@@ -244,6 +244,11 @@
     animation: msg-in 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
+  /* The opener message is present on page load — don't animate it in. */
+  .msg:first-child {
+    animation: none;
+  }
+
   .msg-me {
     background: var(--color-accent);
     color: var(--color-surface);

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,8 @@
   --color-faint: oklch(0.6 0.033 88.408);
   --color-line: oklch(0.906 0.027 85.667);
   --color-line-strong: oklch(0.851 0.039 86.893);
-  --color-accent: oklch(0.587 0.161 37.306);
+  /* L capped at 0.56 so accent text clears 4.5:1 AA on cream (was 4.16:1). */
+  --color-accent: oklch(0.56 0.155 37.306);
   --color-accent-deep: oklch(0.504 0.144 37.069);
   --color-accent-soft: oklch(0.927 0.029 60.755);
   --color-gold: oklch(0.663 0.119 80.097);
@@ -41,6 +42,9 @@
     color: var(--color-ink);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    /* Missing weights/styles should fail visibly, not render browser-faked. */
+    font-synthesis: none;
     text-rendering: optimizeLegibility;
   }
 
@@ -75,7 +79,7 @@
   /* Mono uppercase section kicker */
   .kicker {
     font-family: var(--font-mono);
-    font-size: 0.72rem;
+    font-size: 0.75rem;
     font-weight: 500;
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -161,7 +165,7 @@
     border-radius: 999px;
     padding: 0.15rem 0.6rem;
     font-family: var(--font-mono);
-    font-size: 0.65rem;
+    font-size: 0.75rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
     border: 1px solid var(--color-line);

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,27 +7,27 @@
 */
 
 @theme {
-  --color-cream: #fbf6ed;
-  --color-paper: #f6efe1;
-  --color-surface: #fffdf7;
-  --color-ink: #211d15;
-  --color-soft: #57503f;
-  --color-muted: #756c58;
-  --color-faint: #a39a84;
-  --color-line: #e8dfcc;
-  --color-line-strong: #d9cdb2;
-  --color-accent: #c9512c;
-  --color-accent-deep: #a63e1e;
-  --color-accent-soft: #f6e3d4;
-  --color-gold: #b98a2f;
-  --color-sage: #5f7355;
+  --color-cream: oklch(0.975 0.013 82.402);
+  --color-paper: oklch(0.954 0.02 84.59);
+  --color-surface: oklch(0.994 0.008 91.48);
+  --color-ink: oklch(0.233 0.016 84.478);
+  --color-soft: oklch(0.433 0.028 88.288);
+  --color-muted: oklch(0.495 0.032 86.638);
+  --color-faint: oklch(0.6 0.033 88.408);
+  --color-line: oklch(0.906 0.027 85.667);
+  --color-line-strong: oklch(0.851 0.039 86.893);
+  --color-accent: oklch(0.587 0.161 37.306);
+  --color-accent-deep: oklch(0.504 0.144 37.069);
+  --color-accent-soft: oklch(0.927 0.029 60.755);
+  --color-gold: oklch(0.663 0.119 80.097);
+  --color-sage: oklch(0.531 0.051 135.352);
 
   --font-display: var(--font-fraunces), "Iowan Old Style", Georgia, serif;
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-plex-mono), ui-monospace, "SFMono-Regular", monospace;
 
-  --shadow-card: 0 1px 2px rgb(33 29 21 / 0.04), 0 6px 24px -12px rgb(33 29 21 / 0.16);
-  --shadow-lift: 0 2px 4px rgb(33 29 21 / 0.06), 0 16px 40px -16px rgb(33 29 21 / 0.24);
+  --shadow-card: 0 1px 2px oklch(0.233 0.016 84.478 / 0.04), 0 6px 24px -12px oklch(0.233 0.016 84.478 / 0.16);
+  --shadow-lift: 0 2px 4px oklch(0.233 0.016 84.478 / 0.06), 0 16px 40px -16px oklch(0.233 0.016 84.478 / 0.24);
 }
 
 @layer base {
@@ -135,7 +135,7 @@
   .btn-primary {
     background: var(--color-accent);
     color: var(--color-surface);
-    box-shadow: 0 1px 2px rgb(166 62 30 / 0.35), inset 0 1px 0 rgb(255 255 255 / 0.18);
+    box-shadow: 0 1px 2px oklch(0.504 0.144 37.069 / 0.35), inset 0 1px 0 oklch(1 0 0 / 0.18);
   }
 
   .btn-primary:hover {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,7 +101,12 @@ function WritingSection({ posts }: { posts: SubstackPost[] }) {
             </>
           }
           aside={
-            <a href={site.substackUrl} target="_blank" rel="noopener noreferrer" className="hover:text-accent">
+            <a
+              href={site.substackUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative inline-block transition-colors before:absolute before:-inset-x-1 before:-inset-y-3 before:content-[''] hover:text-accent"
+            >
               {site.substackHandle} ↗
             </a>
           }
@@ -216,7 +221,12 @@ function RecommendationsSection() {
             </>
           }
           aside={
-            <a href={site.linkedinUrl} target="_blank" rel="noopener noreferrer" className="hover:text-accent">
+            <a
+              href={site.linkedinUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative inline-block transition-colors before:absolute before:-inset-x-1 before:-inset-y-3 before:content-[''] hover:text-accent"
+            >
               recommendations via LinkedIn ↗
             </a>
           }
@@ -274,7 +284,12 @@ export default async function Home() {
               </>
             }
             aside={
-              <a href={site.githubUrl} target="_blank" rel="noopener noreferrer" className="hover:text-accent">
+              <a
+                href={site.githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative inline-block transition-colors before:absolute before:-inset-x-1 before:-inset-y-3 before:content-[''] hover:text-accent"
+              >
                 github.com/{site.githubUsername} ↗
               </a>
             }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,8 +80,8 @@ function Hero() {
             fetchPriority="high"
             className="aspect-square w-full rounded-lg bg-paper object-cover outline -outline-offset-1 outline-black/10"
           />
-          <p className="px-2 pb-1 pt-2 text-center font-mono text-[0.65rem] tracking-widest text-faint">
-            EST. SOMEWHERE — STILL SHIPPING
+          <p className="px-2 pb-1 pt-2 text-center font-mono text-[0.65rem] uppercase tracking-widest text-faint">
+            Est. somewhere — still shipping
           </p>
         </div>
       </div>
@@ -118,7 +118,7 @@ function WritingSection({ posts }: { posts: SubstackPost[] }) {
           {posts.slice(0, 3).map((post, i) => (
             <Reveal key={post.link} delay={i * 90}>
               <a href={post.link} target="_blank" rel="noopener noreferrer" className="card group flex h-full flex-col px-6 py-6">
-                <p className="font-mono text-xs text-faint">{formatDate(post.date)}</p>
+                <p className="font-mono text-xs text-muted">{formatDate(post.date)}</p>
                 <h3 className="display mt-3 text-xl leading-snug group-hover:text-accent transition-colors">
                   {post.title}
                 </h3>

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -132,10 +132,10 @@ export default function ActivityFeed({ substackPosts }: { substackPosts: Substac
                   </span>
                   {item.sample && <span className="chip ml-2 align-middle">sample</span>}
                 </span>
-                <span className="hidden shrink-0 font-mono text-xs text-faint sm:inline">
+                <span className="hidden shrink-0 font-mono text-xs text-muted sm:inline">
                   {SOURCE_META[item.source].label}
                 </span>
-                <span className="shrink-0 font-mono text-xs text-faint">
+                <span className="shrink-0 font-mono text-xs text-muted">
                   {relativeTime(item.date)}
                 </span>
               </a>
@@ -144,9 +144,9 @@ export default function ActivityFeed({ substackPosts }: { substackPosts: Substac
       </ul>
 
       {githubFailed && !loading && (
-        <p className="mt-3 font-mono text-xs text-faint">
+        <p className="mt-3 font-mono text-xs text-muted">
           GitHub activity is unavailable right now —{" "}
-          <a href={site.githubUrl} className="underline hover:text-accent" target="_blank" rel="noopener noreferrer">
+          <a href={site.githubUrl} className="underline decoration-line underline-offset-4 hover:text-accent" target="_blank" rel="noopener noreferrer">
             see it on github.com ↗
           </a>
         </p>

--- a/components/ChatStub.tsx
+++ b/components/ChatStub.tsx
@@ -52,8 +52,8 @@ export default function ChatStub() {
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-gold opacity-60" />
           <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-gold" />
         </span>
-        <p className="font-mono text-xs tracking-wide text-muted">
-          AI {site.firstName.toUpperCase()} · PROTOTYPE — NOT YET WIRED TO A MODEL
+        <p className="font-mono text-xs uppercase tracking-wide text-muted">
+          AI {site.firstName} · prototype — not yet wired to a model
         </p>
       </div>
 
@@ -84,7 +84,7 @@ export default function ChatStub() {
           onChange={(e) => setInput(e.target.value)}
           placeholder={`Ask ${site.firstName} anything…`}
           aria-label="Message"
-          className="flex-1 rounded-full border border-line bg-cream px-4 py-2.5 text-sm outline-none transition-colors placeholder:text-faint focus:border-accent"
+          className="flex-1 rounded-full border border-line bg-cream px-4 py-2.5 text-base outline-none transition-colors placeholder:text-muted focus:border-accent sm:text-sm"
         />
         <button type="submit" disabled={!input.trim() || typing} className="btn btn-primary py-2.5 disabled:cursor-not-allowed disabled:opacity-40">
           Send

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -67,10 +67,10 @@ export default function Footer() {
 
       <div className="border-t border-line">
         <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-2 px-5 py-4">
-          <p className="font-mono text-xs text-faint">
+          <p className="font-mono text-xs text-muted">
             © {new Date().getFullYear()} {site.name}
           </p>
-          <p className="font-mono text-xs text-faint">
+          <p className="font-mono text-xs text-muted">
             verify me →{" "}
             <a
               href={site.keybaseUrl}

--- a/components/GithubHighlights.tsx
+++ b/components/GithubHighlights.tsx
@@ -53,7 +53,7 @@ export default function GithubHighlights({ repos }: { repos: Repo[] }) {
           <p className="mt-2 flex-1 text-sm leading-relaxed text-muted">
             {repo.description ?? "No description yet — but the code speaks for itself."}
           </p>
-          <div className="mt-4 flex items-center gap-4 font-mono text-xs text-faint">
+          <div className="mt-4 flex items-center gap-4 font-mono text-xs text-muted">
             {repo.language && (
               <span className="inline-flex items-center gap-1.5">
                 <span

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
       <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-x-4 gap-y-2 px-5 py-3.5">
         <Link
           href="/"
-          className="display text-lg leading-none tracking-tight hover:text-accent transition-colors"
+          className="display relative text-lg leading-none tracking-tight transition-colors before:absolute before:-inset-x-2 before:-inset-y-3 before:content-[''] hover:text-accent"
         >
           {site.shortName}
           <span className="text-accent">.</span>


### PR DESCRIPTION
## Summary
- Migrate all theme color tokens and shadows in `globals.css` from hex/rgb to `oklch` (perceptually uniform, wide-gamut ready)
- Skip the chat opener message's enter animation on first render; only messages added after load animate in
- Extend header logo and section-header aside links to the 40px minimum hit area via invisible pseudo-elements, matching the existing nav/filter pattern
- Typography/contrast pass:
  - Darken accent to `oklch(0.56 0.155 37.306)` so accent text meets WCAG AA 4.5:1 on cream (was 4.15:1); primary-button labels go 4.4 → 4.91:1
  - Informative metadata (feed labels/timestamps, post dates, repo stats, footer legal line, chat footnote, placeholder) moves from `faint` (2.6:1) to `muted` (4.83:1); `faint` remains for decorative flourishes only
  - `.kicker`/`.chip` raised to 12px; `font-synthesis: none` + `-moz-osx-font-smoothing: grayscale` on body
  - Chat input is 16px on mobile so iOS Safari doesn't zoom on focus
  - Uppercase copy stored in natural case, styled via `text-transform`; bare underlines tuned with `decoration-line underline-offset-4`

## Test plan
- [x] `tsc --noEmit`, `eslint .`, `vitest run` (26 passed)
- [x] Contrast ratios verified with WCAG math against the oklch palette
- [ ] Visual spot-check: home, chat, story, philosophy — accent slightly deeper, metadata text slightly darker
- [ ] Chat page: opener bubble appears without animation; input doesn't zoom on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)