### PR TITLE
chore: gitignore .conductor/settings.local.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ next-env.d.ts
 
 # local agent config (may hold secrets)
 .claude/settings.local.json
+.conductor/settings.local.toml


### PR DESCRIPTION
Adds `.conductor/settings.local.toml` to `.gitignore` so personal Conductor workspace settings are not accidentally committed. This matches the existing exclusion for `.claude/settings.local.json` under the "local agent config" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)