### PR TITLE
Fetch GitHub commit counts at build time via authenticated GraphQL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,8 @@ jobs:
         run: pnpm test
       - name: Build
         run: pnpm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:

--- a/components/GithubHighlights.tsx
+++ b/components/GithubHighlights.tsx
@@ -66,6 +66,9 @@ export default function GithubHighlights({ repos }: { repos: Repo[] }) {
             )}
             {repo.stargazers_count > 0 && <span>★ {repo.stargazers_count}</span>}
             {repo.forks_count > 0 && <span>⑂ {repo.forks_count}</span>}
+            {repo.commit_count != null && repo.commit_count > 0 && (
+              <span>↑ {repo.commit_count.toLocaleString()}</span>
+            )}
           </div>
         </a>
       ))}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -13,6 +13,7 @@ export type Repo = {
   pushed_at: string;
   fork: boolean;
   archived: boolean;
+  commit_count?: number;
 };
 
 /** The subset of a GitHub public-events payload the feed cares about. */

--- a/lib/repos.ts
+++ b/lib/repos.ts
@@ -2,27 +2,111 @@ import { site } from "@/lib/site";
 import { pickHighlights, type Repo } from "@/lib/github";
 import { pinnedRepos, highlightCount } from "@/data/projects";
 
-const REPOS_URL = `https://api.github.com/users/${site.githubUsername}/repos?per_page=100&sort=pushed`;
+const GQL_URL = "https://api.github.com/graphql";
+const REST_URL = `https://api.github.com/users/${site.githubUsername}/repos?per_page=100&sort=pushed`;
+
+// Single authenticated request: all repo metadata + commit counts in one shot.
+// Costs 1 GraphQL point (vs. N+1 REST calls to get the same data).
+const GQL_QUERY = `{
+  user(login: "${site.githubUsername}") {
+    repositories(first: 100, orderBy: {field: PUSHED_AT, direction: DESC}) {
+      nodes {
+        name
+        url
+        description
+        stargazerCount
+        forkCount
+        primaryLanguage { name }
+        pushedAt
+        isArchived
+        isFork
+        defaultBranchRef {
+          target {
+            ... on Commit {
+              history { totalCount }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+type GqlRepoNode = {
+  name: string;
+  url: string;
+  description: string | null;
+  stargazerCount: number;
+  forkCount: number;
+  primaryLanguage: { name: string } | null;
+  pushedAt: string;
+  isArchived: boolean;
+  isFork: boolean;
+  defaultBranchRef: { target: { history: { totalCount: number } } | null } | null;
+};
+
+function mapNode(node: GqlRepoNode): Repo {
+  return {
+    name: node.name,
+    html_url: node.url,
+    description: node.description,
+    stargazers_count: node.stargazerCount,
+    forks_count: node.forkCount,
+    language: node.primaryLanguage?.name ?? null,
+    pushed_at: node.pushedAt,
+    fork: node.isFork,
+    archived: node.isArchived,
+    commit_count: node.defaultBranchRef?.target?.history.totalCount,
+  };
+}
+
+async function fetchViaGraphQL(token: string): Promise<Repo[]> {
+  const res = await fetch(GQL_URL, {
+    method: "POST",
+    signal: AbortSignal.timeout(10_000),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+    body: JSON.stringify({ query: GQL_QUERY }),
+  });
+  if (!res.ok) throw new Error(`GitHub GraphQL responded ${res.status}`);
+  const json = (await res.json()) as {
+    data?: { user?: { repositories?: { nodes: GqlRepoNode[] } } };
+    errors?: unknown[];
+  };
+  if (json.errors) throw new Error(`GitHub GraphQL errors: ${JSON.stringify(json.errors)}`);
+  return (json.data?.user?.repositories?.nodes ?? []).map(mapNode);
+}
+
+async function fetchViaREST(): Promise<Repo[]> {
+  const res = await fetch(REST_URL, {
+    signal: AbortSignal.timeout(10_000),
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) throw new Error(`GitHub REST responded ${res.status}`);
+  return (await res.json()) as Repo[];
+}
 
 /**
- * Fetch repo highlights from the GitHub API at build time (the site is a
- * static export), so visitors get pre-rendered cards instead of a client-side
- * fetch that burns the unauthenticated 60 req/hr per-IP rate limit. Highlights
- * refresh on every deploy. If the API is unreachable the site still builds —
- * the section falls back to linking straight to GitHub.
+ * Fetch repo highlights at build time. With GITHUB_TOKEN set, uses a single
+ * authenticated GraphQL request that also returns commit counts (5,000 points/hr).
+ * Without a token, falls back to the unauthenticated REST API (no commit counts,
+ * 60 req/hr per-IP limit). Either way, the site still builds if the API is down.
  */
 export async function getRepoHighlights(): Promise<Repo[]> {
   try {
-    const res = await fetch(REPOS_URL, {
-      // Don't let a hung API hang the deploy — fail fast and fall back.
-      signal: AbortSignal.timeout(10_000),
-      headers: { accept: "application/vnd.github+json" },
-    });
-    if (!res.ok) throw new Error(`GitHub API responded ${res.status}`);
-    const repos = (await res.json()) as Repo[];
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+      console.warn(
+        "[github] GITHUB_TOKEN not set — falling back to unauthenticated REST (no commit counts, 60 req/hr limit)",
+      );
+    }
+    const repos = await (token ? fetchViaGraphQL(token) : fetchViaREST());
     return pickHighlights(repos, pinnedRepos, highlightCount);
   } catch (err) {
-    console.warn(`[github] could not fetch ${REPOS_URL}:`, err);
+    console.warn("[github] could not fetch repo highlights:", err);
     return [];
   }
 }


### PR DESCRIPTION
Replaces the unauthenticated REST repo fetch in \`lib/repos.ts\` with a single authenticated GitHub GraphQL query that returns all repo metadata plus default-branch commit counts in one request (5,000 points/hr vs the 60 req/hr unauthenticated limit). Repo cards in \`GithubHighlights\` now show a commit count alongside stars and forks. The deploy workflow exposes the Actions-provided \`GITHUB_TOKEN\` to the build step; no new secrets needed. Without a token (local dev), the build falls back to the unauthenticated REST API and simply omits commit counts, so builds never break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)