### PR TITLE
chore: add Conductor workspace config

### DIFF
--- a/.conductor/settings.local.toml
+++ b/.conductor/settings.local.toml
@@ -1,0 +1,14 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "pnpm install"
+run_mode = "concurrent"
+
+[scripts.run.dev]
+command = "pnpm dev --port $CONDUCTOR_PORT"
+default = true
+icon = "play"
+
+[scripts.run.test]
+command = "pnpm test:all"
+icon = "test-tube"

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ next-env.d.ts
 
 # local agent config (may hold secrets)
 .claude/settings.local.json
-.conductor/settings.local.toml


### PR DESCRIPTION
Adds `.conductor/settings.local.toml` so new Conductor workspaces auto-run `pnpm install` and expose one-click run scripts. The `dev` script binds `$CONDUCTOR_PORT` (avoiding port-3000 collisions) and `run_mode = "concurrent"` lets parallel workspaces run safely. Also drops `.conductor/settings.local.toml` from `.gitignore` so the config is tracked in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)