### PR TITLE
chore: fix and extend Conductor run scripts

### DIFF
--- a/.conductor/settings.local.toml
+++ b/.conductor/settings.local.toml
@@ -10,5 +10,13 @@ default = true
 icon = "play"
 
 [scripts.run.test]
-command = "pnpm test:all"
+command = "pnpm test"
 icon = "test-tube"
+
+[scripts.run.lint]
+command = "pnpm lint"
+icon = "wrench"
+
+[scripts.run.build]
+command = "pnpm build"
+icon = "package"


### PR DESCRIPTION
Fixes the broken `test` run script in `.conductor/settings.local.toml` — it called `pnpm test:all`, which is not a script in `package.json` (the real one is `pnpm test` → `vitest run`), so it failed immediately from the Conductor Run menu. Also adds `lint` and `build` run scripts that mirror the CI gates in `deploy.yml`, letting an agent self-check before opening a PR. `setup`, `run_mode = "concurrent"`, and the default `dev` script are unchanged. All commands are pnpm, non-interactive, and workspace-safe (dev binds `CONDUCTOR_PORT`, build writes per-workspace `./out`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)