### PR TITLE
Rework theme to E2E1DC five-color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 Personal site of [Andrew H. Carpenter](https://github.com/ahcarpenter) — built
 with Next.js (App Router, static export) and Tailwind CSS v4, deployed to
-GitHub Pages. Light-mode-only theme inspired by [conductor.build](https://conductor.build):
-warm cream paper, serif display type (Fraunces), terracotta accent.
+GitHub Pages. Light-mode-only theme: warm-neutral paper (`#E2E1DC`), serif
+display type (Fraunces), electric-blue accent for links, plum for primary
+buttons, magenta for the chat CTA and source dots. Buttons are pushable —
+a solid darker edge sits under the face, which travels on hover and press.
+
+Colors live entirely in the `@theme` block of `app/globals.css` as OKLCH
+tokens — Tailwind v4 is CSS-first here, there is no `tailwind.config`.
+`app/theme.test.ts` guards them: every token must sit inside the sRGB gamut
+(Lightning CSS silently clips out-of-gamut values to hex at build time), clear
+WCAG AA against the backgrounds it actually lands on, and stay in sync with the
+two places `--color-page` has to be mirrored as a literal (`app/icon.svg` and
+the `themeColor` in `app/layout.tsx`).
 
 ## Pages
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,37 +1,58 @@
 @import "tailwindcss";
 
 /*
-  Light-only theme inspired by conductor.build:
-  warm cream paper, high-contrast serif display type,
-  terracotta accent, thin warm borders, soft rounded cards.
+  Light-only theme: warm-neutral paper (E2E1DC and its own hue), pure-black
+  ink, electric-blue accent for links, plum for primary buttons, magenta for
+  their hover state and for solid dots.
+
+  `static` so tokens referenced only from JS are never tree-shaken out.
 */
 
-@theme {
-  --color-cream: oklch(0.975 0.013 82.402);
-  --color-paper: oklch(0.954 0.02 84.59);
-  --color-surface: oklch(0.994 0.008 91.48);
-  --color-ink: oklch(0.233 0.016 84.478);
-  --color-soft: oklch(0.433 0.028 88.288);
-  --color-muted: oklch(0.495 0.032 86.638);
-  --color-faint: oklch(0.6 0.033 88.408);
-  --color-line: oklch(0.906 0.027 85.667);
-  --color-line-strong: oklch(0.851 0.039 86.893);
-  /* L capped at 0.56 so accent text clears 4.5:1 AA on cream (was 4.16:1). */
-  --color-accent: oklch(0.56 0.155 37.306);
-  --color-accent-deep: oklch(0.504 0.144 37.069);
-  --color-accent-soft: oklch(0.927 0.029 60.755);
-  --color-gold: oklch(0.663 0.119 80.097);
-  --color-sage: oklch(0.531 0.051 135.352);
-  /* LinkedIn brand blue — a third-party brand color, kept in sRGB hex (like the
-     language brand colors in lib/language-colors.ts) rather than an OKLCH token. */
-  --color-linkedin: #4a6c8c;
+@theme static {
+  /* Neutrals — all on the page background's own hue (97.36), so every tint
+     and shade of the page reads as the same paper, never warm/cool drift. */
+  --color-surface: oklch(0.985 0.004 97.36); /* #fbfaf7  raised: cards, inputs */
+  /* The page. Mirrored in app/icon.svg and app/layout.tsx `themeColor` —
+     app/theme.test.ts asserts all three stay equal to #E2E1DC. */
+  --color-page: oklch(0.9091 0.0068 97.36); /* #e2e1dc */
+  --color-paper: oklch(0.868 0.009 97.36); /* #d5d4cd  recessed: footer, chat header */
+  --color-line: oklch(0.828 0.011 97.36); /* #c8c7bf */
+  --color-line-strong: oklch(0.762 0.013 97.36); /* #b4b2a9 */
+  /* L 0.545, not 0.6: keeps the de-emphasised captions on cards at 4.76:1. */
+  --color-faint: oklch(0.545 0.014 97.36); /* #727067 */
+  /* L 0.47, not 0.495: 0.495 is only 4.32:1 on the footer's paper/60 bed. */
+  --color-muted: oklch(0.47 0.014 97.36); /* #5d5b52  4.81:1 in footer */
+  --color-soft: oklch(0.4 0.013 97.36); /* #494840  7.02:1 on page */
+  --color-ink: oklch(0 0 0); /* #000000  16.04:1 on page */
+
+  /* Accent = links and emphasis text. Blue because it is the only chromatic
+     in the palette that clears 4.5:1 as text on the page (6.85:1). */
+  --color-accent: oklch(0.435 0.2801 264.21); /* #001ee7  6.85 page / 8.60 surface */
+  /* C capped at 0.2536 = the sRGB gamut edge at this L; 0.255 renders
+     out-of-gamut on P3 and would not match --color-accent's sRGB anchor. */
+  --color-accent-deep: oklch(0.365 0.2536 264.21); /* #0100c0  9.08 page; white on it 11.90 */
+  /* L 0.89, not 0.925: blue's max chroma at 0.925 is only 0.0355, too pale to
+     separate the borderless active nav pill from the page. */
+  --color-accent-soft: oklch(0.89 0.05 264.21); /* #cadbfd  accent-deep on it 8.55:1 */
+
+  /* Mark = solid shapes only — the .btn-mark CTA, source dots, status.
+     Never carries small text in white: white-on-mark is 3.28:1, so labels on
+     --color-mark are ink. */
+  --color-mark: oklch(0.6699 0.185 334.13); /* #d662c3  ink on it 6.39:1 */
+
+  /* Deep = primary-button fill, and the darkest chromatic in the palette. */
+  --color-deep: oklch(0.3253 0.0583 319.17); /* #412a47  surface on it 12.22:1 */
 
   --font-display: var(--font-fraunces), "Iowan Old Style", Georgia, serif;
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-plex-mono), ui-monospace, "SFMono-Regular", monospace;
 
-  --shadow-card: 0 1px 2px oklch(0.233 0.016 84.478 / 0.04), 0 6px 24px -12px oklch(0.233 0.016 84.478 / 0.16);
-  --shadow-lift: 0 2px 4px oklch(0.233 0.016 84.478 / 0.06), 0 16px 40px -16px oklch(0.233 0.016 84.478 / 0.24);
+  --shadow-card:
+    0 1px 2px color-mix(in oklab, var(--color-ink) 4%, transparent),
+    0 6px 24px -12px color-mix(in oklab, var(--color-ink) 16%, transparent);
+  --shadow-lift:
+    0 2px 4px color-mix(in oklab, var(--color-ink) 6%, transparent),
+    0 16px 40px -16px color-mix(in oklab, var(--color-ink) 24%, transparent);
 }
 
 @layer base {
@@ -41,7 +62,7 @@
   }
 
   body {
-    background-color: var(--color-cream);
+    background-color: var(--color-page);
     color: var(--color-ink);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
@@ -58,6 +79,20 @@
   ::selection {
     background: var(--color-accent-soft);
     color: var(--color-accent-deep);
+  }
+
+  /* One focus ring for the whole site. Offset so it lands on the surface
+     behind the control rather than on a plum/magenta fill, where an accent
+     ring would only reach 2.7:1. */
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+
+  /* Feed rows span the full width of their card, which clips overflow — a
+     positive offset would be shaved to ~1px. Draw this one inward instead. */
+  ul.card a:focus-visible {
+    outline-offset: -2px;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -122,42 +157,76 @@
     transform: translateY(-2px);
   }
 
-  /* Buttons */
+  /*
+    Buttons, in the pushable style posthog.com uses: a solid darker edge sits
+    under the face, the face travels on hover/press, and the bottom of the
+    assembly stays put so nothing reflows. PostHog builds this from two nested
+    elements; a hard `box-shadow` renders identically from one, which keeps
+    <a> and <button> markup untouched.
+
+    Hover is the travel only — no color change — so a variant reads as one
+    color throughout. Each variant sets just its face and --btn-edge, and the
+    edge is mixed down from the face so it follows the token rather than being
+    a second hand-tuned literal that can drift.
+  */
   .btn {
+    position: relative;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    border-radius: 999px;
-    padding: 0.625rem 1.25rem;
+    border: 1.5px solid var(--btn-edge);
+    border-radius: 8px;
+    padding: 0.5rem 1.15rem;
     font-size: 0.9rem;
     font-weight: 600;
-    transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease,
-      transform 150ms ease, box-shadow 150ms ease;
+    box-shadow: 0 2px 0 var(--btn-edge);
+    transition: transform 100ms ease, box-shadow 100ms ease,
+      background-color 150ms ease, color 150ms ease, border-color 150ms ease;
   }
 
-  .btn:active {
-    transform: translateY(1px) scale(0.96);
+  /* Faces run 35-41px tall, under the 44px touch target. Extend with a
+     pseudo-element rather than padding so the PostHog proportions hold. A
+     fixed 44px band rather than a relative inset, so every size lands on 44
+     exactly. Vertical only: buttons sit side by side, so growing x collides. */
+  .btn::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 0;
+    left: 0;
+    height: 44px;
+    transform: translateY(-50%);
+  }
+
+  /* Rises 1px while the edge grows 1px — bottom edge holds still. */
+  .btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 3px 0 var(--btn-edge);
+  }
+
+  .btn:active:not(:disabled) {
+    transform: translateY(1px);
+    box-shadow: 0 1px 0 var(--btn-edge);
   }
 
   .btn-primary {
-    background: var(--color-accent);
+    --btn-edge: color-mix(in oklab, var(--color-deep) 74%, black);
+    background: var(--color-deep);
     color: var(--color-surface);
-    box-shadow: 0 1px 2px oklch(0.504 0.144 37.069 / 0.35), inset 0 1px 0 oklch(1 0 0 / 0.18);
   }
 
-  .btn-primary:hover {
-    background: var(--color-accent-deep);
+  /* The magenta CTA. Its label is ink, not surface: white on --color-mark is
+     only 3.28:1, ink on it is 6.39:1. */
+  .btn-mark {
+    --btn-edge: color-mix(in oklab, var(--color-mark) 74%, black);
+    background: var(--color-mark);
+    color: var(--color-ink);
   }
 
   .btn-secondary {
-    background: transparent;
-    color: var(--color-ink);
-    border: 1px solid var(--color-line-strong);
-  }
-
-  .btn-secondary:hover {
+    --btn-edge: var(--color-line-strong);
     background: var(--color-surface);
-    border-color: var(--color-faint);
+    color: var(--color-ink);
   }
 
   /* Source chips in the activity feed */
@@ -172,7 +241,7 @@
     letter-spacing: 0.08em;
     text-transform: uppercase;
     border: 1px solid var(--color-line);
-    background: var(--color-cream);
+    background: var(--color-page);
     color: var(--color-muted);
   }
 
@@ -263,8 +332,10 @@
     margin-left: auto;
   }
 
+  /* Page, not surface: this bubble sits inside a .card, which is already
+     surface — a surface fill would leave it invisible but for its border. */
   .msg-bot {
-    background: var(--color-surface);
+    background: var(--color-page);
     border: 1px solid var(--color-line);
     border-bottom-left-radius: 0.3rem;
   }

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="14" fill="#fbf6ed"/>
-  <rect x="1" y="1" width="62" height="62" rx="13" fill="none" stroke="#e8dfcc" stroke-width="2"/>
-  <text x="32" y="44" text-anchor="middle" font-family="Georgia, serif" font-style="italic" font-size="34" fill="#c9512c">ac</text>
+  <rect width="64" height="64" rx="14" fill="#e2e1dc"/>
+  <rect x="1" y="1" width="62" height="62" rx="13" fill="none" stroke="#c8c7bf" stroke-width="2"/>
+  <text x="32" y="44" text-anchor="middle" font-family="Georgia, serif" font-style="italic" font-size="34" fill="#001ee7">ac</text>
 </svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,8 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   colorScheme: "light",
-  themeColor: "#fbf6ed",
+  /* Mirrors --color-page in app/globals.css; app/theme.test.ts keeps them equal. */
+  themeColor: "#e2e1dc",
 };
 
 export default function RootLayout({

--- a/app/story/page.tsx
+++ b/app/story/page.tsx
@@ -33,7 +33,7 @@ export default function StoryPage() {
                 {/* Dot on the line, marking the date + event header */}
                 <span
                   aria-hidden
-                  className="tl-dot absolute left-0 top-1.5 h-[15px] w-[15px] rounded-full border-[3px] border-accent bg-cream sm:h-[19px] sm:w-[19px]"
+                  className="tl-dot absolute left-0 top-1.5 h-[15px] w-[15px] rounded-full border-[3px] border-accent bg-page sm:h-[19px] sm:w-[19px]"
                 />
                 <div className="tl-head pl-9 sm:pl-12">
                   <p className="font-mono text-xs uppercase tracking-[0.18em] text-accent">

--- a/app/theme.test.ts
+++ b/app/theme.test.ts
@@ -1,0 +1,243 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { LANGUAGE_COLORS } from "@/lib/language-colors";
+
+/**
+ * Guards the design tokens in app/globals.css. Three classes of bug this
+ * catches, all of which slipped past a hand contrast-check during the palette
+ * rework:
+ *   1. a token that fails WCAG AA against a background it actually lands on
+ *      (notably composited ones like the footer's `bg-paper/60`),
+ *   2. a token outside the sRGB gamut, which renders differently on P3 than
+ *      its in-gamut siblings,
+ *   3. drift between --color-page and the two places it has to be mirrored as
+ *      a literal (app/icon.svg, app/layout.tsx `themeColor`).
+ *
+ * The color math lives here rather than in lib/ because nothing at runtime
+ * needs it.
+ */
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const read = (p: string) => readFileSync(path.join(ROOT, p), "utf8");
+
+/** Every file under the given repo-relative directories, recursively. */
+const walk = (dirs: string[]): string[] =>
+  dirs.flatMap((dir) =>
+    readdirSync(path.join(ROOT, dir), { withFileTypes: true }).flatMap((entry) => {
+      const rel = `${dir}/${entry.name}`;
+      return entry.isDirectory() ? walk([rel]) : [rel];
+    }),
+  );
+
+type Oklch = [L: number, C: number, H: number];
+type Rgb = [r: number, g: number, b: number];
+
+/** OKLCH -> linear sRGB. Values outside [0,1] mean out of gamut. */
+function toLinearSrgb([L, C, H]: Oklch): Rgb {
+  const hRad = (H * Math.PI) / 180;
+  const a = C * Math.cos(hRad);
+  const b = C * Math.sin(hRad);
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+
+const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+
+function toSrgb8(color: Oklch): Rgb {
+  return toLinearSrgb(color).map((v) => {
+    const c = clamp01(v);
+    const encoded = c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055;
+    return Math.round(encoded * 255);
+  }) as Rgb;
+}
+
+const toHex = (color: Oklch) =>
+  `#${toSrgb8(color)
+    .map((v) => v.toString(16).padStart(2, "0"))
+    .join("")}`;
+
+function relativeLuminance([r, g, b]: Rgb): number {
+  const [lr, lg, lb] = [r, g, b].map((v) => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+}
+
+function contrastRatio(fg: Rgb, bg: Rgb): number {
+  const [hi, lo] = [relativeLuminance(fg), relativeLuminance(bg)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Simple alpha composite, for tokens rendered over a translucent bed. */
+const over = (fg: Rgb, bg: Rgb, alpha: number) =>
+  fg.map((v, i) => Math.round(v * alpha + bg[i] * (1 - alpha))) as Rgb;
+
+const oklabOf = ([L, C, H]: Oklch): Rgb => {
+  const hRad = (H * Math.PI) / 180;
+  return [L, C * Math.cos(hRad), C * Math.sin(hRad)];
+};
+
+const deltaE = (a: Oklch, b: Oklch) => Math.hypot(...oklabOf(a).map((v, i) => v - oklabOf(b)[i]));
+
+/** Deliberately strict: a reformatted @theme block should fail loudly here. */
+function parseThemeTokens(): Record<string, Oklch> {
+  const css = read("app/globals.css");
+  const block = /@theme static \{([\s\S]*?)\n\}/.exec(css);
+  expect(block, "could not locate the `@theme static { ... }` block").not.toBeNull();
+
+  const tokens: Record<string, Oklch> = {};
+  for (const [, name, args] of block![1].matchAll(/--color-([a-z-]+):\s*oklch\(([^)]+)\)/g)) {
+    const parts = args.trim().split(/\s+/).map(Number);
+    expect(parts, `--color-${name} is not three numbers`).toHaveLength(3);
+    tokens[name] = parts as Oklch;
+  }
+  return tokens;
+}
+
+const TOKENS = parseThemeTokens();
+const rgb = (name: string): Rgb => {
+  const token = TOKENS[name];
+  if (!token) throw new Error(`no --color-${name} in the @theme block`);
+  return toSrgb8(token);
+};
+
+describe("theme tokens", () => {
+  it("parses every color token out of the @theme block", () => {
+    expect(Object.keys(TOKENS).sort()).toEqual([
+      "accent",
+      "accent-deep",
+      "accent-soft",
+      "deep",
+      "faint",
+      "ink",
+      "line",
+      "line-strong",
+      "mark",
+      "muted",
+      "page",
+      "paper",
+      "soft",
+      "surface",
+    ]);
+  });
+
+  it.each(Object.entries(TOKENS))("--color-%s is inside the sRGB gamut", (_name, color) => {
+    for (const channel of toLinearSrgb(color)) {
+      expect(channel).toBeGreaterThanOrEqual(-0.0005);
+      expect(channel).toBeLessThanOrEqual(1.0005);
+    }
+  });
+
+  // Only pairs that actually occur in the markup. `min` is the WCAG level the
+  // pair has to clear: 4.5 for body text, 3 for large text and decoration.
+  const PAIRS: Array<[label: string, fg: Rgb, bg: Rgb, min: number]> = [
+    ["accent on page (body links)", rgb("accent"), rgb("page"), 4.5],
+    ["accent on surface (card hover)", rgb("accent"), rgb("surface"), 4.5],
+    ["muted on page (chips, timestamps)", rgb("muted"), rgb("page"), 4.5],
+    // Footer.tsx and ChatStub.tsx put text on `bg-paper/60` over the page.
+    ["muted on paper/60 (footer)", rgb("muted"), over(rgb("paper"), rgb("page"), 0.6), 4.5],
+    ["soft on page (body copy)", rgb("soft"), rgb("page"), 4.5],
+    ["surface on deep (.btn-primary label)", rgb("surface"), rgb("deep"), 4.5],
+    ["ink on mark (.btn-primary:hover label)", rgb("ink"), rgb("mark"), 4.5],
+    ["surface on accent (.msg-me)", rgb("surface"), rgb("accent"), 4.5],
+    ["accent-deep on accent-soft (nav pill)", rgb("accent-deep"), rgb("accent-soft"), 4.5],
+    ["faint on surface (card captions)", rgb("faint"), rgb("surface"), 4.5],
+    ["ink on page", rgb("ink"), rgb("page"), 4.5],
+  ];
+
+  it.each(PAIRS)("%s clears its contrast floor", (_label, fg, bg, min) => {
+    expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(min);
+  });
+
+  // PAIRS proves two tokens are compatible; it does not prove the stylesheet
+  // pairs them that way. This catches e.g. a `.btn-primary:hover` that keeps a
+  // surface label when its fill moves to --color-mark (3.28:1).
+  it("keeps every rule that sets both a token fill and a token label legible", () => {
+    const css = read("app/globals.css").replace(/\/\*[\s\S]*?\*\//g, "");
+    const rules = [...css.matchAll(/([^{}]+)\{([^}]*)\}/g)].flatMap(([, selector, body]) => {
+      const bg = /(?:^|[\s;])background(?:-color)?:\s*var\(--color-([a-z-]+)\)/.exec(body);
+      const fg = /(?:^|[\s;])color:\s*var\(--color-([a-z-]+)\)/.exec(body);
+      return bg && fg ? [{ selector: selector.trim(), bg: bg[1], fg: fg[1] }] : [];
+    });
+
+    // If a refactor renames these rules, fail rather than silently check nothing.
+    expect(rules.length).toBeGreaterThanOrEqual(5);
+
+    for (const { selector, bg, fg } of rules) {
+      expect(contrastRatio(rgb(fg), rgb(bg)), `${selector} (${fg} on ${bg})`).toBeGreaterThanOrEqual(
+        4.5,
+      );
+    }
+  });
+
+  it("keeps --color-page in sync with its two hardcoded mirrors", () => {
+    // Neither can reference the token: icon.svg is served before any CSS
+    // exists, and `themeColor` must be a literal in the metadata object.
+    const page = toHex(TOKENS.page);
+    expect(page).toBe("#e2e1dc");
+
+    const iconFill = /<rect[^>]*\sfill="(#[0-9a-f]{6})"/i.exec(read("app/icon.svg"));
+    expect(iconFill?.[1].toLowerCase(), "app/icon.svg background fill").toBe(page);
+
+    const themeColor = /themeColor:\s*"(#[0-9a-fA-F]{6})"/.exec(read("app/layout.tsx"));
+    expect(themeColor?.[1].toLowerCase(), "app/layout.tsx themeColor").toBe(page);
+  });
+
+  it("has no raw Tailwind palette classes left in the markup", () => {
+    // The palette lives entirely in @theme, so a stock Tailwind color would be
+    // an untracked value that silently stops following the tokens.
+    const stock =
+      /\b(?:bg|text|border|outline|fill|stroke|divide|ring|decoration|shadow)-(?:black|white|slate|gray|grey|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)\b/;
+
+    // Image outlines are the one deliberate exception: they must be pure
+    // black at 10%, never a themed neutral. A tinted outline picks up the
+    // surface under it and reads as dirt on the image edge, so these must NOT
+    // follow --color-ink even while it happens to be pure black.
+    const imageOutline = /\boutline-(?:black|white)\/\d+\b/g;
+
+    const offenders = walk(["app", "components"])
+      .filter((file) => file.endsWith(".tsx"))
+      .filter((file) => stock.test(read(file).replace(imageOutline, "")));
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("language dot colors", () => {
+  const parsed = Object.entries(LANGUAGE_COLORS).map(([language, value]) => {
+    const args = /^oklch\(([^)]+)\)$/.exec(value);
+    expect(args, `${language} is not a bare oklch() value`).not.toBeNull();
+    return [language, args![1].trim().split(/\s+/).map(Number) as Oklch] as const;
+  });
+
+  it.each(parsed)("%s is inside the sRGB gamut", (_language, color) => {
+    for (const channel of toLinearSrgb(color)) {
+      expect(channel).toBeGreaterThanOrEqual(-0.0005);
+      expect(channel).toBeLessThanOrEqual(1.0005);
+    }
+  });
+
+  it.each(parsed)("%s is legible on a card", (_language, color) => {
+    // Decorative dots beside a text label, so the large-text floor applies.
+    expect(contrastRatio(toSrgb8(color), rgb("surface"))).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps every pair of dots visually distinct", () => {
+    // The Linguist brand set this replaced bottomed out at 0.031.
+    for (let i = 0; i < parsed.length; i++) {
+      for (let j = i + 1; j < parsed.length; j++) {
+        const [aName, a] = parsed[i];
+        const [bName, b] = parsed[j];
+        expect(deltaE(a, b), `${aName} vs ${bName}`).toBeGreaterThan(0.08);
+      }
+    }
+  });
+});

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import ExternalLink from "@/components/ExternalLink";
+import SourceIcon from "@/components/SourceIcon";
 import { linkedinActivity } from "@/data/linkedin";
 import { recentReads } from "@/data/reading";
 import type { SubstackPost } from "@/lib/sources/substack/substack";
@@ -9,11 +10,11 @@ import type { GithubFeedItem } from "@/lib/sources/github/events";
 import { buildFeed, type Source } from "@/lib/content/feed";
 import { relativeTime } from "@/lib/format";
 
-const SOURCE_META: Record<Source, { label: string; dot: string }> = {
-  github: { label: "GitHub", dot: "var(--color-sage)" },
-  linkedin: { label: "LinkedIn", dot: "var(--color-linkedin)" },
-  substack: { label: "Substack", dot: "var(--color-accent)" },
-  reading: { label: "Reading", dot: "var(--color-gold)" },
+const SOURCE_LABEL: Record<Source, string> = {
+  github: "GitHub",
+  linkedin: "LinkedIn",
+  substack: "Substack",
+  reading: "Reading",
 };
 
 const FILTERS: Array<{ key: Source | "all"; label: string }> = [
@@ -48,17 +49,20 @@ export default function ActivityFeed({
 
   return (
     <div>
-      <div className="flex flex-wrap gap-x-2 gap-y-3">
+      {/* gap-y-4 (16px) is what lets the pills' -inset-y-2 hit areas reach 44px
+          without overlapping each other when the row wraps. */}
+      <div className="flex flex-wrap gap-x-2 gap-y-4">
         {FILTERS.map((f) => (
           <button
             key={f.key}
             onClick={() => setFilter(f.key)}
-            className={`relative rounded-full border px-3 py-1.5 font-mono text-xs tracking-wide transition-[color,background-color,border-color,scale] before:absolute before:inset-x-0 before:-inset-y-1.5 before:content-[''] active:scale-[0.96] ${
+            className={`relative inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 font-mono text-xs tracking-wide transition-[color,background-color,border-color,scale] before:absolute before:inset-x-0 before:-inset-y-2 before:content-[''] active:scale-[0.96] ${
               filter === f.key
                 ? "border-accent bg-accent-soft text-accent-deep"
                 : "border-line bg-surface text-muted hover:border-line-strong hover:text-ink"
             }`}
           >
+            <SourceIcon source={f.key} />
             {f.label}
           </button>
         ))}
@@ -73,21 +77,22 @@ export default function ActivityFeed({
           <li key={`${item.source}-${item.date}-${i}`}>
             <ExternalLink
               href={item.url}
-              className="group flex items-baseline gap-4 px-5 py-4 transition-colors hover:bg-cream/60"
+              className="group flex items-baseline gap-4 px-5 py-4 transition-colors hover:bg-page/60"
             >
-              <span
-                aria-hidden
-                className="relative top-[-1px] h-2 w-2 shrink-0 self-center rounded-full"
-                style={{ background: SOURCE_META[item.source].dot }}
-              />
               <span className="min-w-0 flex-1 text-sm leading-snug text-ink">
                 <span className="group-hover:underline decoration-line underline-offset-4">
                   {item.title}
                 </span>
                 {item.sample && <span className="chip ml-2 align-middle">sample</span>}
               </span>
-              <span className="hidden shrink-0 font-mono text-xs text-muted sm:inline">
-                {SOURCE_META[item.source].label}
+              {/* The mark replaces the source name here, so it carries the only
+                  visible cue — the label stays for screen readers. Baseline,
+                  not centre: on a title that wraps to two lines, centring drops
+                  the mark to the second line while the timestamp stays on the
+                  first. The nudge sits it optically on the text baseline. */}
+              <span className="shrink-0 translate-y-[3px] self-baseline">
+                <SourceIcon source={item.source} />
+                <span className="sr-only">{SOURCE_LABEL[item.source]}</span>
               </span>
               <span className="shrink-0 font-mono text-xs text-muted">
                 {relativeTime(item.date)}

--- a/components/ChatStub.tsx
+++ b/components/ChatStub.tsx
@@ -49,8 +49,8 @@ export default function ChatStub() {
     <div className="card flex h-[32rem] flex-col overflow-hidden">
       <div className="flex items-center gap-3 border-b border-line bg-paper/50 px-5 py-3">
         <span className="relative flex h-2.5 w-2.5">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-gold opacity-60" />
-          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-gold" />
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-mark opacity-60" />
+          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-mark" />
         </span>
         <p className="font-mono text-xs uppercase tracking-wide text-muted">
           AI {site.firstName} · prototype — not yet wired to a model
@@ -84,7 +84,7 @@ export default function ChatStub() {
           onChange={(e) => setInput(e.target.value)}
           placeholder={`Ask ${site.firstName} anything…`}
           aria-label="Message"
-          className="flex-1 rounded-full border border-line bg-cream px-4 py-2.5 text-base outline-none transition-colors placeholder:text-muted focus:border-accent sm:text-sm"
+          className="flex-1 rounded-full border border-line bg-page px-4 py-2.5 text-base transition-colors placeholder:text-muted focus:border-accent sm:text-sm"
         />
         <button type="submit" disabled={!input.trim() || typing} className="btn btn-primary py-2.5 disabled:cursor-not-allowed disabled:opacity-40">
           Send

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-40 border-b border-line bg-cream/85 backdrop-blur-md">
+    <header className="sticky top-0 z-40 border-b border-line bg-page/85 backdrop-blur-md">
       <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-x-4 gap-y-2 px-5 py-3.5">
         <Link
           href="/"
@@ -33,7 +33,7 @@ export default function Header() {
             <Link
               key={l.href}
               href={l.href}
-              className={`relative rounded-full px-3 py-1.5 text-sm font-medium transition-colors before:absolute before:inset-x-0 before:-inset-y-1 before:content-[''] ${
+              className={`relative rounded-full px-3 py-1.5 text-sm font-medium transition-[color,background-color,scale] before:absolute before:inset-x-0 before:-inset-y-1.5 before:content-[''] active:scale-[0.96] ${
                 isActive(l.href)
                   ? "bg-accent-soft text-accent-deep"
                   : "text-soft hover:bg-surface hover:text-ink"
@@ -45,7 +45,7 @@ export default function Header() {
           {cta && (
             <Link
               href={cta.href}
-              className="btn btn-primary relative ml-1 px-4 py-1.5 text-sm before:absolute before:inset-x-0 before:-inset-y-1 before:content-['']"
+              className="btn btn-mark relative ml-1 px-4 py-1.5 text-sm before:absolute before:inset-x-0 before:-inset-y-1 before:content-['']"
             >
               <span className="sm:hidden">{cta.label}</span>
               <span className="hidden sm:inline">{cta.label} with me</span>

--- a/components/SourceIcon.tsx
+++ b/components/SourceIcon.tsx
@@ -1,0 +1,74 @@
+import type { Source } from "@/lib/content/feed";
+import { sourceBrandColor } from "@/lib/source-brand";
+
+/** The activity feed's four sources plus the "no filter" case. */
+export type SourceIconKey = Source | "all";
+
+/*
+  Brand marks are solid paths (that is the form the trademarks take); the two
+  generic icons are strokes at a heavier width so they don't read lighter than
+  the solid marks at 14px.
+*/
+const BRAND_MARKS: Record<"github" | "linkedin" | "substack", string> = {
+  github:
+    "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12",
+  linkedin:
+    "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z",
+  substack: "M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z",
+};
+
+function Mark({ d }: { d: string }) {
+  return <path d={d} fill="currentColor" />;
+}
+
+/** Feather-style globe, for the unfiltered "Everything" case. */
+function GlobeMark() {
+  return (
+    <g fill="none" stroke="currentColor" strokeWidth={2.25} strokeLinecap="round">
+      <circle cx="12" cy="12" r="9.5" />
+      <path d="M2.5 12h19" />
+      <path d="M12 2.5a14.5 14.5 0 0 1 0 19 14.5 14.5 0 0 1 0-19z" />
+    </g>
+  );
+}
+
+/** Feather-style closed book, for the reading source. */
+function BookMark() {
+  return (
+    <g fill="none" stroke="currentColor" strokeWidth={2.25} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+      <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+    </g>
+  );
+}
+
+/**
+ * The mark for a feed source. Purely presentational: it is always
+ * `aria-hidden`, so any caller that isn't already adjacent to the source name
+ * must supply its own accessible label.
+ */
+export default function SourceIcon({
+  source,
+  className = "h-3.5 w-3.5",
+  brand = true,
+}: {
+  source: SourceIconKey;
+  className?: string;
+  /** When false the mark inherits `currentColor` instead of its brand color. */
+  brand?: boolean;
+}) {
+  const color = brand ? sourceBrandColor(source) : undefined;
+
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      className={`shrink-0 ${className}`}
+      style={color ? { color } : undefined}
+    >
+      {source === "all" && <GlobeMark />}
+      {source === "reading" && <BookMark />}
+      {source !== "all" && source !== "reading" && <Mark d={BRAND_MARKS[source]} />}
+    </svg>
+  );
+}

--- a/lib/language-colors.ts
+++ b/lib/language-colors.ts
@@ -1,29 +1,43 @@
 /**
- * Brand colors for the language dot on repo cards. These are third-party brand
- * colors (as used by github-linguist), deliberately kept as sRGB hex rather than
- * promoted into the OKLCH design tokens in app/globals.css — they aren't part of
- * this site's palette, they just echo GitHub's.
+ * The language dot on repo cards. Derived from the site palette in
+ * app/globals.css rather than GitHub Linguist's brand colors: four families
+ * (accent blue, mark magenta, deep plum, neutral) x four lightness steps.
+ * Plum is separated from magenta by chroma, not hue — they are only 15 deg
+ * apart and collapse into each other at high chroma.
+ *
+ * Kept as literal oklch() rather than --color-* tokens: this is a
+ * presentational ramp, not a design token set, and literals cannot be
+ * tree-shaken out of a `style` attribute.
+ *
+ * Min pairwise OKLab dE is 0.090 — the Linguist set it replaces was 0.031,
+ * since those are per-language brand marks and were never designed to work as
+ * a categorical scale. All values are in sRGB gamut and >= 3:1 on
+ * --color-surface. Guarded by lib/language-colors.test.ts.
  */
 export const LANGUAGE_COLORS: Record<string, string> = {
-  TypeScript: "#3178c6",
-  JavaScript: "#f1e05a",
-  Python: "#3572A5",
-  Go: "#00ADD8",
-  Rust: "#dea584",
-  Ruby: "#701516",
-  Java: "#b07219",
-  Kotlin: "#A97BFF",
-  Swift: "#F05138",
-  C: "#555555",
-  "C++": "#f34b7d",
-  "C#": "#178600",
-  HTML: "#e34c26",
-  CSS: "#663399",
-  Shell: "#89e051",
-  Elixir: "#6e4a7e",
+  // accent blue 264.21 — TypeScript is --color-accent exactly
+  Python: "oklch(0.3 0.19 264.21)",
+  TypeScript: "oklch(0.435 0.2801 264.21)",
+  Go: "oklch(0.56 0.22 264.21)",
+  JavaScript: "oklch(0.645 0.17 264.21)",
+  // mark magenta 334.13 — Rust is --color-mark exactly
+  Ruby: "oklch(0.36 0.15 334.13)",
+  Elixir: "oklch(0.47 0.19 334.13)",
+  Swift: "oklch(0.57 0.21 334.13)",
+  Rust: "oklch(0.6699 0.185 334.13)",
+  // deep plum 319.17, low chroma — Java is --color-deep exactly
+  Java: "oklch(0.3253 0.0583 319.17)",
+  Kotlin: "oklch(0.44 0.07 319.17)",
+  "C#": "oklch(0.545 0.08 319.17)",
+  "C++": "oklch(0.65 0.085 319.17)",
+  // neutral 97.36 — C is --color-ink exactly
+  C: "oklch(0 0 0)",
+  Shell: "oklch(0.4 0.013 97.36)",
+  HTML: "oklch(0.52 0.014 97.36)",
+  CSS: "oklch(0.64 0.014 97.36)",
 };
 
-/** The dot color for a repo's primary language, falling back to a neutral token. */
+/** The dot color for a repo's primary language, falling back to a neutral. */
 export function languageColor(language: string | null): string {
-  return (language && LANGUAGE_COLORS[language]) || "var(--color-faint)";
+  return (language && LANGUAGE_COLORS[language]) || "oklch(0.52 0.014 97.36)";
 }

--- a/lib/source-brand.ts
+++ b/lib/source-brand.ts
@@ -1,0 +1,29 @@
+import type { Source } from "@/lib/content/feed";
+
+/**
+ * Brand colors for the source marks in the activity feed. Kept as sRGB hex
+ * outside the OKLCH token system for the same reason as the language colors in
+ * lib/language-colors.ts: they belong to third parties, not to this site's
+ * palette, so they must not drift when the theme changes.
+ *
+ * `reading` and `all` are deliberately absent — they aren't brands, so their
+ * icons inherit `currentColor` from the surrounding control.
+ *
+ * Substack is deepened from its official #ff6719. In the feed the mark
+ * replaces the source name outright, which makes it the only indicator of
+ * where a row came from, so WCAG 1.4.11 asks for 3:1. Official orange reaches
+ * only 2.79:1 on --color-surface, 2.23:1 on --color-page and 2.09:1 on the
+ * active filter pill. Holding its OKLCH hue and chroma and dropping lightness
+ * 0.698 -> 0.60 gives 4.14 / 3.30 / 3.10 — the lightest tone that clears 3:1
+ * on all three beds, so it stays recognisably Substack orange.
+ */
+const SOURCE_BRAND: Partial<Record<Source, string>> = {
+  github: "#181717",
+  linkedin: "#0a66c2",
+  substack: "#db4500",
+};
+
+/** The brand color for a source, or undefined when it should inherit. */
+export function sourceBrandColor(source: string): string | undefined {
+  return SOURCE_BRAND[source as Source];
+}


### PR DESCRIPTION
Reworks the site theme to the palette E2E1DC / 000000 / D662C3 / 412A47 / 001EE7, assigning colors by role: blue takes links (the only chromatic clearing WCAG AA as text on the new page background), plum fills primary buttons, magenta is reserved for solid marks with ink labels, and all neutrals derive from E2E1DC's own hue. Buttons are restyled in posthog.com's pushable style — a darker mixed-down edge under a face that travels on hover/press — plus a global focus-visible ring, 44px hit areas, and press feedback on pills. Feed source labels and dots are replaced with brand icons (GitHub, LinkedIn, Substack, book, globe), with Substack's orange deepened to clear 3:1 as the sole source indicator and sr-only labels preserving row accessibility. GitHub language dots move off Linguist brand hexes onto a palette-derived ramp, tripling minimum pairwise color separation. A new app/theme.test.ts guards sRGB gamut (Lightning CSS silently clips out-of-gamut OKLCH at build), contrast on real composited backgrounds, and the icon.svg/themeColor mirrors of --color-page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)